### PR TITLE
Use optional_depends in mod.conf

### DIFF
--- a/mod.conf
+++ b/mod.conf
@@ -1,4 +1,4 @@
 name = moarmour
 description = Additional armors to build and wear
 depends = default,3d_armor
-optional = nyancats_plus,waffles,farming,nanotech,even_mosword,candycane,moreores,bones,bonemeal,xpanes,tac_nayn,sky_tools,emeralds,gems,terumet
+optional_depends = nyancats_plus,waffles,farming,nanotech,even_mosword,candycane,moreores,bones,bonemeal,xpanes,tac_nayn,sky_tools,emeralds,gems,terumet


### PR DESCRIPTION
According to [the minetest api doc](https://github.com/minetest/minetest/blob/master/doc/lua_api.txt), it is `optional_depends` that they recommend using instead of `optional`.