### PR TITLE
Add ediblestuff_api as an optional dependancy.

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -10,3 +10,7 @@ moarmour = {
 dofile(moarmour_path.."/nodes.lua")
 dofile(moarmour_path.."/crafts.lua")
 dofile(moarmour_path.."/armour.lua")
+-- Optional mod-specific stuff --
+if minetest.get_modpath("ediblestuff_api") then
+	dofile(moarmour_path.."/make_edible.lua")
+end

--- a/make_edible.lua
+++ b/make_edible.lua
@@ -1,0 +1,11 @@
+if minetest.get_modpath("waffles") then
+	-- A waffle block is 9 waffles, 8 stamina each. This is huge.
+	-- Let's just do 20 for all waffle armor peices.
+	ediblestuff.make_armor_edible_while_wearing("moarmour","waffle",20,true)
+end
+if minetest.get_modpath("farming") and farming.mod == "redo" then
+	ediblestuff.make_armor_edible_while_wearing("moarmour","chocolate",2.5)
+end
+if minetest.get_modpath("candycane") then
+	ediblestuff.make_armor_edible_while_wearing("moarmour","cane",3.5)
+end

--- a/mod.conf
+++ b/mod.conf
@@ -1,4 +1,4 @@
 name = moarmour
 description = Additional armors to build and wear
 depends = default,3d_armor
-optional_depends = nyancats_plus,waffles,farming,nanotech,even_mosword,candycane,moreores,bones,bonemeal,xpanes,tac_nayn,sky_tools,emeralds,gems,terumet
+optional_depends = nyancats_plus,waffles,farming,nanotech,even_mosword,candycane,moreores,bones,bonemeal,xpanes,tac_nayn,sky_tools,emeralds,gems,terumet,ediblestuff_api


### PR DESCRIPTION
This will allow players to eat chocolate, waffle, and candycane armor,
even while wearing it, if `ediblestuff_api` is present